### PR TITLE
Tidy up prefixes & ontology contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This is an extension to RDF and SPARQL that introduces 2 new datatypes, dozens o
 ## Features
 
 - **New datatypes:**
-  - `dt:NumericDataTensor` – represents tensors containing numeric values.
-  - `dt:BooleanDataTensor` – represents tensors containing boolean values.
+  - `tensor:NumericDataTensor` – represents tensors containing numeric values.
+  - `tensor:BooleanDataTensor` – represents tensors containing boolean values.
 - **New SPARQL functions:**
   - Tensor manipulations (addition, multiplication, reshaping, etc.)
   - Algebraic computations

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@
 ## Abstract
 
 This specification defines an approach to represent data tensors (multi-dimensional arrays) as literals in RDF.
-It introduces two new RDF datatypes – `dt:NumericDataTensor` and `dt:BooleanDataTensor`, along with an extension of the SPARQL language.
+It introduces two new RDF datatypes – `tensor:NumericDataTensor` and `tensor:BooleanDataTensor`, along with an extension of the SPARQL language.
 This extension includes 36 functions and 6 aggregates, enabling the efficient processing of tensor data within RDF frameworks.
 
 **[See our paper for more information](https://arxiv.org/abs/2504.19224)**
@@ -31,19 +31,17 @@ Examples in this document assume that the following prefixes have been declared 
 
 **Prefixes used:**
 
-| Prefix | Namespace                                 |
-|--------|-------------------------------------------|
-| `ex`   | `http://example.org/data-tensor#`         |
-| `dt`   | `https://w3id.org/rdf-tensor/datatypes#`  |
-| `dtf`  | `https://w3id.org/rdf-tensor/functions#`  |
-| `dta`  | `https://w3id.org/rdf-tensor/aggregates#` |
-| `xsd`  | `http://www.w3.org/2001/XMLSchema#`       |
+| Prefix     | Namespace                             |
+|------------|---------------------------------------|
+| `ex`       | `http://example.org/data-tensor#`     |
+| `tensor`   | `https://w3id.org/rdf-tensor/vocab#`  |
+| `xsd`      | `http://www.w3.org/2001/XMLSchema#`   |
 
 
-## 2. The `dt:NumericDataTensor` Datatype
+## 2. The `tensor:NumericDataTensor` Datatype
 ### IRI
 
-[`https://w3id.org/rdf-tensor/datatypes#NumericDataTensor`](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor)
+[`https://w3id.org/rdf-tensor/vocab#NumericDataTensor`](https://w3id.org/rdf-tensor/vocab#NumericDataTensor)
 
 ### Definition
 
@@ -75,15 +73,15 @@ After parsing, the JSON object is converted into a tensor structure.
 !!! example
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [3, 2], \"data\": [0.1, 1.2, 2.2, 3.2, 4.1, 5.4e2]}"^^dt:NumericDataTensor
-    "{\"type\": \"int32\", \"shape\": [1, 2, 2, 2], \"data\": [1, 3, 4, 12, 22, 32, 41, 5]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [3, 2], \"data\": [0.1, 1.2, 2.2, 3.2, 4.1, 5.4e2]}"^^tensor:NumericDataTensor
+    "{\"type\": \"int32\", \"shape\": [1, 2, 2, 2], \"data\": [1, 3, 4, 12, 22, 32, 41, 5]}"^^tensor:NumericDataTensor
     ```
 
-## 3. The `dt:BooleanDataTensor` Datatype
+## 3. The `tensor:BooleanDataTensor` Datatype
 
 ### IRI
 
-[`https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor`](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor)
+[`https://w3id.org/rdf-tensor/vocab#BooleanDataTensor`](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor)
 
 ### Definition
 
@@ -113,16 +111,16 @@ After parsing, the JSON object is converted into a tensor structure.
 !!! example
 
     ```turtle
-    "{\"shape\": [2, 2], \"data\": [true, false, false, true]}"^^dt:BooleanDataTensor .
-    "{\"shape\": [2, 2, 2], \"data\": [true, false, false, true, false, false, false, true]}"^^dt:BooleanDataTensor .
+    "{\"shape\": [2, 2], \"data\": [true, false, false, true]}"^^tensor:BooleanDataTensor .
+    "{\"shape\": [2, 2, 2], \"data\": [true, false, false, true, false, false, false, true]}"^^tensor:BooleanDataTensor .
     ```
 
 ## 4. SPARQL Functions
 ### 4.1. Transforming Functions
 
-#### `dtf:cos`
+#### `tensor:cos`
 
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:cos** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:cos** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
 The result of the function is a tensor of the same shape as the input tensor, where each element is replaced by its cosine value.
 
@@ -131,19 +129,19 @@ The result of the function is a tensor of the same shape as the input tensor, wh
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:cos("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [0, 3.1415]}"^^dt:NumericDataTensor)
+    tensor:cos("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [0, 3.1415]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, -1]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, -1]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:exp`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:exp** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+#### `tensor:exp`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:exp** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
 The result of the function is a tensor of the same shape as the input tensor, where each element is replaced by its exponential value.
 
@@ -152,20 +150,20 @@ The result of the function is a tensor of the same shape as the input tensor, wh
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:exp("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [0, 1]}"^^dt:NumericDataTensor)
+    tensor:exp("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [0, 1]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, 2.7183]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, 2.7183]}"^^tensor:NumericDataTensor
     ```
 
 
 ---
 
-#### `dtf:log`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:log** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+#### `tensor:log`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:log** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
 The result of the function is a tensor of the same shape as the input tensor, where each element is replaced by its natural logarithm value.
 
@@ -174,19 +172,19 @@ The result of the function is a tensor of the same shape as the input tensor, wh
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:log("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, 2.7183]}"^^dt:NumericDataTensor)
+    tensor:log("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, 2.7183]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [0, 1]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [0, 1]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:logp`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:logp** (xsd:double *p*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+#### `tensor:logp`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:logp** (xsd:double *p*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
 The result is a tensor of the same shape, where each element is replaced by its logarithm with base *p*.
 
@@ -195,19 +193,19 @@ The result is a tensor of the same shape, where each element is replaced by its 
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:logp(10, "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, 10]}"^^dt:NumericDataTensor)
+    tensor:logp(10, "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, 10]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [0, 1]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [0, 1]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:poly`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:poly** (xsd:double *n*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+#### `tensor:poly`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:poly** (xsd:double *n*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
 The result is a tensor where each element is raised to the power *n*.
 
@@ -216,19 +214,19 @@ The result is a tensor where each element is raised to the power *n*.
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:poly(2, "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [2, 3]}"^^dt:NumericDataTensor)
+    tensor:poly(2, "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [2, 3]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [4, 9]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [4, 9]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:scale`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:scale** (xsd:double *factor*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+#### `tensor:scale`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:scale** (xsd:double *factor*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
 The result is a tensor of the same shape, where each element is multiplied by the given scalar factor.
 
@@ -237,19 +235,19 @@ The result is a tensor of the same shape, where each element is multiplied by th
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:scale(3, "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [2, 3]}"^^dt:NumericDataTensor)
+    tensor:scale(3, "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [2, 3]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [6, 9]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [6, 9]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:sin`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:sin** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+#### `tensor:sin`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:sin** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
 The result of the function is a tensor of the same shape as the input tensor, where each element is replaced by its sine value.
 
@@ -258,19 +256,19 @@ The result of the function is a tensor of the same shape as the input tensor, wh
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:sin("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [0, 3.1415]}"^^dt:NumericDataTensor)
+    tensor:sin("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [0, 3.1415]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [0, 0]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [0, 0]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:abs`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:abs** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+#### `tensor:abs`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:abs** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
 The result of the function is a tensor of the same shape as the input tensor, where each element is replaced by its absolute value.
 
@@ -279,19 +277,19 @@ The result of the function is a tensor of the same shape as the input tensor, wh
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:abs("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [-1, 2]}"^^dt:NumericDataTensor)
+    tensor:abs("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [-1, 2]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, 2]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, 2]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:cast`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:cast** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*, xsd:string *type*)
+#### `tensor:cast`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:cast** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*, xsd:string *type*)
 
 The result of the function is a tensor of the same shape as the input tensor, where each element is cast to the specified type. The supported types are: `float16`, `float32`, `float64`, `int16`, `int32`, and `int64`.
 
@@ -300,21 +298,21 @@ The result of the function is a tensor of the same shape as the input tensor, wh
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:cast("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1.5, 2.5]}"^^dt:NumericDataTensor, "int32")
+    tensor:cast("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1.5, 2.5]}"^^tensor:NumericDataTensor, "int32")
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"int32\", \"shape\": [1, 2], \"data\": [1, 2]}"^^dt:NumericDataTensor
+    "{\"type\": \"int32\", \"shape\": [1, 2], \"data\": [1, 2]}"^^tensor:NumericDataTensor
     ```
 
 ### 4.2 Operators
 
 When using the binary operators, the input tensors are broadcasted to a common shape. The broadcasting rules are the same as in NumPy**[[NumPy 8259](#numpy)]**. In the case of numeric tensors, the result of the mathematical operation is a tensor with the more precise type of the two input tensors. For example, if one tensor is `float32` and the other is `int32`, the result will be `float32`. 
 
-#### `dtf:not`
-[dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) **dtf:not** ([dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) *term_1*)
+#### `tensor:not`
+[tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) **tensor:not** ([tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) *term_1*)
 
 The result of the function is a tensor of the same shape as the input tensor, where each element is logically negated.
 
@@ -323,19 +321,19 @@ The result of the function is a tensor of the same shape as the input tensor, wh
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:not("{\"type\": \"bool\", \"shape\": [1, 2], \"data\": [true, false]}"^^dt:BooleanDataTensor)
+    tensor:not("{\"type\": \"bool\", \"shape\": [1, 2], \"data\": [true, false]}"^^tensor:BooleanDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"bool\", \"shape\": [1, 2], \"data\": [false, true]}"^^dt:BooleanDataTensor
+    "{\"type\": \"bool\", \"shape\": [1, 2], \"data\": [false, true]}"^^tensor:BooleanDataTensor
     ```
 
 ---
 
-#### `dtf:add`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:add** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_2*)
+#### `tensor:add`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:add** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_2*)
 
 The result of the function is a tensor of broadcasted shape, where each element is the sum of corresponding elements in the input tensors.
 
@@ -344,13 +342,13 @@ The result of the function is a tensor of broadcasted shape, where each element 
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:add("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, 2]}"^^dt:NumericDataTensor, "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [3, 4]}"^^dt:NumericDataTensor)
+    tensor:add("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, 2]}"^^tensor:NumericDataTensor, "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [3, 4]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [4, 6]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [4, 6]}"^^tensor:NumericDataTensor
     ```
 
 
@@ -359,19 +357,19 @@ The result of the function is a tensor of broadcasted shape, where each element 
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:add("{\"type\":\"float32\",\"shape\":[1, 2, 2], \"data\":[3, 2, 3, 4]}"^^dt:NumericDataTensor, "{\"type\":\"int32\",\"shape\":[1],\"data\":[1, 2]}"^^dt:NumericDataTensor)
+    tensor:add("{\"type\":\"float32\",\"shape\":[1, 2, 2], \"data\":[3, 2, 3, 4]}"^^tensor:NumericDataTensor, "{\"type\":\"int32\",\"shape\":[1],\"data\":[1, 2]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [1, 2, 2], \"data\": [4, 4, 4, 6]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [1, 2, 2], \"data\": [4, 4, 4, 6]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:subtract`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:subtract** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_2*)
+#### `tensor:subtract`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:subtract** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_2*)
 
 The result of the function is a tensor of broadcasted shape, where each element is the difference between corresponding elements in the input tensors.
 
@@ -381,13 +379,13 @@ The result of the function is a tensor of broadcasted shape, where each element 
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:subtract("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [5, 7]}"^^dt:NumericDataTensor, "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [2, 3]}"^^dt:NumericDataTensor)
+    tensor:subtract("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [5, 7]}"^^tensor:NumericDataTensor, "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [2, 3]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [3, 4]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [3, 4]}"^^tensor:NumericDataTensor
     ```
 
 
@@ -396,19 +394,19 @@ The result of the function is a tensor of broadcasted shape, where each element 
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:subtract("{\"type\":\"float32\",\"shape\":[2, 2], \"data\":[3, 2, 3, 4]}"^^dt:NumericDataTensor, "{\"type\":\"int32\",\"shape\":[2],\"data\":[2, 1]}"^^dt:NumericDataTensor)
+    tensor:subtract("{\"type\":\"float32\",\"shape\":[2, 2], \"data\":[3, 2, 3, 4]}"^^tensor:NumericDataTensor, "{\"type\":\"int32\",\"shape\":[2],\"data\":[2, 1]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [2, 2], \"data\": [1, 1, 1, 3]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [2, 2], \"data\": [1, 1, 1, 3]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:multiply`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:multiply** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_2*)
+#### `tensor:multiply`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:multiply** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_2*)
 
 The result of the function is a tensor of broadcasted shape, where each element is the product of corresponding elements in the input tensors.
 
@@ -417,13 +415,13 @@ The result of the function is a tensor of broadcasted shape, where each element 
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:multiply("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [2, 3]}"^^dt:NumericDataTensor, "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [4, 5]}"^^dt:NumericDataTensor)
+    tensor:multiply("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [2, 3]}"^^tensor:NumericDataTensor, "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [4, 5]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [8, 15]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [8, 15]}"^^tensor:NumericDataTensor
     ```
 
 
@@ -432,19 +430,19 @@ The result of the function is a tensor of broadcasted shape, where each element 
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:multiply("{\"type\":\"int32\",\"shape\":[2, 2], \"data\":[3, 2, 3, 4]}"^^dt:NumericDataTensor, "{\"type\":\"int32\",\"shape\":[2],\"data\":[2, 1]}"^^dt:NumericDataTensor)
+    tensor:multiply("{\"type\":\"int32\",\"shape\":[2, 2], \"data\":[3, 2, 3, 4]}"^^tensor:NumericDataTensor, "{\"type\":\"int32\",\"shape\":[2],\"data\":[2, 1]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [2, 2], \"data\": [6, 2, 6, 4]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [2, 2], \"data\": [6, 2, 6, 4]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:divide`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:divide** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_2*)
+#### `tensor:divide`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:divide** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_2*)
 
 The result of the function is a tensor of broadcasted shape, where each element is the quotient of corresponding elements in the input tensors.
 
@@ -453,13 +451,13 @@ The result of the function is a tensor of broadcasted shape, where each element 
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:divide("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [8, 9]}", "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [2, 3]}")
+    tensor:divide("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [8, 9]}", "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [2, 3]}")
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [4, 3]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [4, 3]}"^^tensor:NumericDataTensor
     ```
 
 
@@ -468,22 +466,22 @@ The result of the function is a tensor of broadcasted shape, where each element 
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:divide("{\"type\":\"int32\",\"shape\":[2, 2], \"data\":[3, 2, 3, 4]}"^^dt:NumericDataTensor, "{\"type\":\"int32\",\"shape\":[2],\"data\":[2, 1]}"^^dt:NumericDataTensor)
+    tensor:divide("{\"type\":\"int32\",\"shape\":[2, 2], \"data\":[3, 2, 3, 4]}"^^tensor:NumericDataTensor, "{\"type\":\"int32\",\"shape\":[2],\"data\":[2, 1]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"int32\", \"shape\": [2, 2], \"data\": [1, 2, 1, 2]}"^^dt:NumericDataTensor
+    "{\"type\": \"int32\", \"shape\": [2, 2], \"data\": [1, 2, 1, 2]}"^^tensor:NumericDataTensor
     ```
 
 
 ---
 
-#### `dtf:eq`
-[dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) **dtf:eq** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_2*)
+#### `tensor:eq`
+[tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) **tensor:eq** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_2*)
 
-[dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) **dtf:eq** ([dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) *term_1*, [dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) *term_2*)
+[tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) **tensor:eq** ([tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) *term_1*, [tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) *term_2*)
 
 The function returns a boolean tensor with a broadcasted shape, where each element is `true` if the corresponding elements in the two tensors are equal, and `false` otherwise.
 
@@ -492,13 +490,13 @@ The function returns a boolean tensor with a broadcasted shape, where each eleme
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:eq("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, 2]}", "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, 3]}")
+    tensor:eq("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, 2]}", "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, 3]}")
     ```
 
     returns
 
     ```turtle
-    "{\"shape\": [1, 2], \"data\": [true, false]}"^^dt:BooleanDataTensor
+    "{\"shape\": [1, 2], \"data\": [true, false]}"^^tensor:BooleanDataTensor
     ```
 
 
@@ -507,22 +505,22 @@ The function returns a boolean tensor with a broadcasted shape, where each eleme
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:eq("\"shape\": [1, 2], \"data\": [true, false]}", "{\"shape\": [1], \"data\": [true]}")
+    tensor:eq("\"shape\": [1, 2], \"data\": [true, false]}", "{\"shape\": [1], \"data\": [true]}")
     ```
 
     returns
 
     ```turtle
-    "{\"shape\": [1, 2], \"data\": [true, false]}"^^dt:BooleanDataTensor
+    "{\"shape\": [1, 2], \"data\": [true, false]}"^^tensor:BooleanDataTensor
     ```
 
 ---
 
-#### `dtf:neq`
+#### `tensor:neq`
 
-[dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) **dtf:neq** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_2*)
+[tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) **tensor:neq** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_2*)
 
-[dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) **dtf:neq** ([dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) *term_1*, [dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) *term_2*)
+[tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) **tensor:neq** ([tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) *term_1*, [tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) *term_2*)
 
 
 The function returns a boolean tensor with a broadcasted shape, where each element is `true` if the corresponding elements in the two tensors are not equal, and `false` otherwise.
@@ -532,13 +530,13 @@ The function returns a boolean tensor with a broadcasted shape, where each eleme
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:neq("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, 2]}", "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, 3]}")
+    tensor:neq("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, 2]}", "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [1, 3]}")
     ```
 
     returns
 
     ```turtle
-    "{\"shape\": [1, 2], \"data\": [false, true]}"^^dt:BooleanDataTensor
+    "{\"shape\": [1, 2], \"data\": [false, true]}"^^tensor:BooleanDataTensor
     ```
 
 
@@ -547,19 +545,19 @@ The function returns a boolean tensor with a broadcasted shape, where each eleme
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:neq("\"shape\": [1, 2], \"data\": [true, false]}", "{\"shape\": [1], \"data\": [true]}")
+    tensor:neq("\"shape\": [1, 2], \"data\": [true, false]}", "{\"shape\": [1], \"data\": [true]}")
     ```
 
     returns
 
     ```turtle
-    "{\"shape\": [1, 2], \"data\": [false, true]}"^^dt:BooleanDataTensor
+    "{\"shape\": [1, 2], \"data\": [false, true]}"^^tensor:BooleanDataTensor
     ```
 
 ---
 
-#### `dtf:and`
-[dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) **dtf:and** ([dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) *term_1*, [dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) *term_2*)
+#### `tensor:and`
+[tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) **tensor:and** ([tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) *term_1*, [tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) *term_2*)
 
 The function returns a boolean tensor with a broadcasted shape, where each element is the logical AND of the input tensors.
 
@@ -568,19 +566,19 @@ The function returns a boolean tensor with a broadcasted shape, where each eleme
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:and("{\"shape\": [1, 2], \"data\": [true, false]}", "{\"shape\": [1, 2], \"data\": [true, true]}")
+    tensor:and("{\"shape\": [1, 2], \"data\": [true, false]}", "{\"shape\": [1, 2], \"data\": [true, true]}")
     ```
 
     returns
 
     ```turtle
-    "{\"shape\": [1, 2], \"data\": [true, false]}"^^dt:BooleanDataTensor
+    "{\"shape\": [1, 2], \"data\": [true, false]}"^^tensor:BooleanDataTensor
     ```
 
 ---
 
-#### `dtf:or`
-[dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) **dtf:or** ([dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) *term_1*, [dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) *term_2*)
+#### `tensor:or`
+[tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) **tensor:or** ([tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) *term_1*, [tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) *term_2*)
 
 The function returns a boolean tensor with a broadcasted shape, where each element is the logical OR of the input tensors.
 
@@ -589,19 +587,19 @@ The function returns a boolean tensor with a broadcasted shape, where each eleme
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:or("{\"shape\": [1, 2], \"data\": [true, false]}", "{\"shape\": [1, 2], \"data\": [false, true]}")
+    tensor:or("{\"shape\": [1, 2], \"data\": [true, false]}", "{\"shape\": [1, 2], \"data\": [false, true]}")
     ```
 
     returns
 
     ```turtle
-    "{\"shape\": [1, 2], \"data\": [true, true]}"^^dt:BooleanDataTensor
+    "{\"shape\": [1, 2], \"data\": [true, true]}"^^tensor:BooleanDataTensor
     ```
 
 ---
 
-#### `dtf:gt`
-[dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) **dtf:gt** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_2*)
+#### `tensor:gt`
+[tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) **tensor:gt** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_2*)
 
 The function returns a boolean tensor with a broadcasted shape, where each element is `true` if the corresponding element from *term_1* is greater than the corresponding element from *term_2*, and `false` otherwise.
 
@@ -610,19 +608,19 @@ The function returns a boolean tensor with a broadcasted shape, where each eleme
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:gt("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [4, 2]}", "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [3, 3]}")
+    tensor:gt("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [4, 2]}", "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [3, 3]}")
     ```
 
     returns
 
     ```turtle
-    "{\"shape\": [1, 2], \"data\": [true, false]}"^^dt:BooleanDataTensor
+    "{\"shape\": [1, 2], \"data\": [true, false]}"^^tensor:BooleanDataTensor
     ```
 
 ---
 
-#### `dtf:lt`
-[dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) **dtf:lt** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_2*)
+#### `tensor:lt`
+[tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) **tensor:lt** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_2*)
 
 The function returns a boolean tensor with a broadcasted shape, where each element is `true` if the corresponding element from *term_1* is lesser than the corresponding element from *term_2*, and `false` otherwise.
 
@@ -631,25 +629,25 @@ The function returns a boolean tensor with a broadcasted shape, where each eleme
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:lt("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [4, 2]}", "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [3, 3]}")
+    tensor:lt("{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [4, 2]}", "{\"type\": \"float32\", \"shape\": [1, 2], \"data\": [3, 3]}")
     ```
 
     returns
 
     ```turtle
-    "{\"shape\": [1, 2], \"data\": [false, true]}"^^dt:BooleanDataTensor
+    "{\"shape\": [1, 2], \"data\": [false, true]}"^^tensor:BooleanDataTensor
     ```
 
 ### 4.3. Indexing Functions
 
-#### `dtf:getSubDT`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:getSubDT** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *tensor*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#DataTensor) *indexTensor*)
+#### `tensor:getSubDT`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:getSubDT** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *tensor*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#DataTensor) *indexTensor*)
 
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:getSubDT** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *tensor*, [dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#DataTensor) *indexTensor*)
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:getSubDT** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *tensor*, [tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#DataTensor) *indexTensor*)
 
-[dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) **dtf:getSubDT** ([dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *tensor*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#DataTensor) *indexTensor*)
+[tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) **tensor:getSubDT** ([tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *tensor*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#DataTensor) *indexTensor*)
 
-[dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) **dtf:getSubDT** ([dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) *tensor*, [dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) *indexTensor*)
+[tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) **tensor:getSubDT** ([tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) *tensor*, [tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) *indexTensor*)
 
 The result of the function is a sub-tensor extracted from the input numerical tensor using the boolean or numerical index tensor. The selection depends on the structure and values of the index tensor.
 
@@ -659,13 +657,13 @@ The result of the function is a sub-tensor extracted from the input numerical te
 
     Evaluating the SPARQL expression
     ```sparql
-    dtf:getSubDT("{\"type\":\"int32\",\"shape\":[8],\"data\":[3, 2, 3, 4, 3, 2, 3, 4]}"^^dt:NumericDataTensor, "{\"type\":\"int32\",\"shape\":[2],\"data\":[0, 1]}"^^dt:NumericDataTensor)
+    tensor:getSubDT("{\"type\":\"int32\",\"shape\":[8],\"data\":[3, 2, 3, 4, 3, 2, 3, 4]}"^^tensor:NumericDataTensor, "{\"type\":\"int32\",\"shape\":[2],\"data\":[0, 1]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"int32\", \"shape\": [1, 2], \"data\": [1, 3]}"^^dt:NumericDataTensor
+    "{\"type\": \"int32\", \"shape\": [1, 2], \"data\": [1, 3]}"^^tensor:NumericDataTensor
     ```
   
 * When the tensor is multi-dimensional, and the number of rows in the *index tensor* is equal to the number of dimensions in the tensor, the index tensor is a 2-dimensional tensor where each row contains indices for each dimension. The result is a 1-dimensional tensor containing the elements at those indices.
@@ -675,13 +673,13 @@ The result of the function is a sub-tensor extracted from the input numerical te
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:getSubDT("{\"type\":\"int32\",\"shape\":[2, 2],\"data\":[3, 2, 3, 4]}"^^dt:NumericDataTensor, "{\"type\":\"int32\",\"shape\":[2, 2],\"data\":[0, 1, 1, 0]}"^^dt:NumericDataTensor)
+    tensor:getSubDT("{\"type\":\"int32\",\"shape\":[2, 2],\"data\":[3, 2, 3, 4]}"^^tensor:NumericDataTensor, "{\"type\":\"int32\",\"shape\":[2, 2],\"data\":[0, 1, 1, 0]}"^^tensor:NumericDataTensor)
     ```
     
     returns
   
     ```turtle
-    "{\"type\": \"int32\", \"shape\": [2], \"data\": [3, 4]}"^^dt:NumericDataTensor
+    "{\"type\": \"int32\", \"shape\": [2], \"data\": [3, 4]}"^^tensor:NumericDataTensor
     ```
 
 * When the tensor is multi-dimensional, and the number of rows in the *index tensor* is not equal to the number of dimensions in the tensor, than slice indexing is performed (depends on the index tensor dimensionality).
@@ -693,13 +691,13 @@ The result of the function is a sub-tensor extracted from the input numerical te
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:getSubDT("{\"type\":\"int32\",\"shape\":[2, 2, 2],\"data\":[1, 2, 3, 4, 5, 6, 7, 8]}"^^dt:NumericDataTensor, "{\"type\":\"int32\",\"shape\":[1, 1],\"data\":[1]}"^^dt:NumericDataTensor)
+    tensor:getSubDT("{\"type\":\"int32\",\"shape\":[2, 2, 2],\"data\":[1, 2, 3, 4, 5, 6, 7, 8]}"^^tensor:NumericDataTensor, "{\"type\":\"int32\",\"shape\":[1, 1],\"data\":[1]}"^^tensor:NumericDataTensor)
     ```
     
     returns
         
     ```turtle
-    "{\"type\": \"int32\", \"shape\": [2, 2], \"data\": [5, 6, 7, 8]}"^^dt:NumericDataTensor
+    "{\"type\": \"int32\", \"shape\": [2, 2], \"data\": [5, 6, 7, 8]}"^^tensor:NumericDataTensor
     ```
     
   - The index tensor is 2-dimensional, than slicing is performed firstly the first dimension, and then the second dimension, and the result is a tensor with the same number of dimensions as the input tensor, but with the first two dimensions reduced to the lengths of the *index tensor*.
@@ -709,13 +707,13 @@ The result of the function is a sub-tensor extracted from the input numerical te
     Evaluating the SPARQL expression
             
     ```sparql
-    dtf:getSubDT("{\"type\":\"int32\",\"shape\":[2, 2, 2],\"data\":[1, 2, 3, 4, 5, 6, 7, 8]}"^^dt:NumericDataTensor, "{\"type\":\"int32\",\"shape\":[2, 2],\"data\":[0, 0, 1, 1]}"^^dt:NumericDataTensor)
+    tensor:getSubDT("{\"type\":\"int32\",\"shape\":[2, 2, 2],\"data\":[1, 2, 3, 4, 5, 6, 7, 8]}"^^tensor:NumericDataTensor, "{\"type\":\"int32\",\"shape\":[2, 2],\"data\":[0, 0, 1, 1]}"^^tensor:NumericDataTensor)
     ```
         
     returns
         
     ```turtle 
-    "{\"type\": \"int32\", \"shape\": [2], \"data\": [3, 4, 3, 4]}"^^dt:NumericDataTensor
+    "{\"type\": \"int32\", \"shape\": [2], \"data\": [3, 4, 3, 4]}"^^tensor:NumericDataTensor
     ```
             
   - When the index tensor is more than 3-dimensional, the function will raise an error, as it is not supported.
@@ -727,20 +725,20 @@ The result of the function is a sub-tensor extracted from the input numerical te
     Evaluating the SPARQL expression
                 
     ```sparql
-    dtf:getSubDT("{\"type\":\"int32\",\"shape\":[2, 2],\"data\":[3, 2, 3, 4]}"^^dt:NumericDataTensor, "{\"type\":\"bool\",\"shape\":[2, 2],\"data\":[true, false, true, true]}"^^dt:BooleanDataTensor)
+    tensor:getSubDT("{\"type\":\"int32\",\"shape\":[2, 2],\"data\":[3, 2, 3, 4]}"^^tensor:NumericDataTensor, "{\"type\":\"bool\",\"shape\":[2, 2],\"data\":[true, false, true, true]}"^^tensor:BooleanDataTensor)
     ```
             
     returns
             
     ```turtle
-    "{\"type\": \"int32\", \"shape\": [3], \"data\": [3, 3, 4]}"^^dt:NumericDataTensor
+    "{\"type\": \"int32\", \"shape\": [3], \"data\": [3, 3, 4]}"^^tensor:NumericDataTensor
     ```
 
 
 ### 4.4 Concatenating Functions
 
-#### `dtf:concat`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:concat** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_2*)
+#### `tensor:concat`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:concat** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_2*)
 
 This function returns a tensor that is the concatenation of the two input tensors along the specified axis. The other dimensions must match.
 
@@ -749,17 +747,17 @@ This function returns a tensor that is the concatenation of the two input tensor
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:concat(0, "{\"type\": \"float32\", \"shape\": [2, 2], \"data\": [1, 2, 3, 4]}"^^dt:NumericDataTensor, "{\"type\": \"float32\", \"shape\": [2, 2], \"data\": [5, 6, 7, 8]}"^^dt:NumericDataTensor)
+    tensor:concat(0, "{\"type\": \"float32\", \"shape\": [2, 2], \"data\": [1, 2, 3, 4]}"^^tensor:NumericDataTensor, "{\"type\": \"float32\", \"shape\": [2, 2], \"data\": [5, 6, 7, 8]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [4, 2], \"data\": [1, 2, 3, 4, 5, 6, 7, 8]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [4, 2], \"data\": [1, 2, 3, 4, 5, 6, 7, 8]}"^^tensor:NumericDataTensor
     ```
 
-#### `dtf:hstack`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:hstack** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_2*)
+#### `tensor:hstack`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:hstack** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_2*)
 
 This function returns a tensor that is the result of horizontally stacking the two input tensors (i.e., concatenation along the last axis). The tensors must be broadcast-compatible along other dimensions.
 
@@ -768,19 +766,19 @@ This function returns a tensor that is the result of horizontally stacking the t
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:hstack("{\"type\": \"float32\", \"shape\": [2, 2], \"data\": [1, 2, 3, 4]}"^^dt:NumericDataTensor, "{\"type\": \"float32\", \"shape\": [2, 2], \"data\": [5, 6, 7, 8]}"^^dt:NumericDataTensor)
+    tensor:hstack("{\"type\": \"float32\", \"shape\": [2, 2], \"data\": [1, 2, 3, 4]}"^^tensor:NumericDataTensor, "{\"type\": \"float32\", \"shape\": [2, 2], \"data\": [5, 6, 7, 8]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [2, 4], \"data\": [1, 2, 5, 6, 3, 4, 7, 8]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [2, 4], \"data\": [1, 2, 5, 6, 3, 4, 7, 8]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:vstack`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:vstack** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_2*)
+#### `tensor:vstack`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:vstack** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_2*)
 
 This function returns a tensor that is the result of vertically stacking the two input tensors (i.e., concatenation along the first axis). The tensors must be broadcast-compatible along other dimensions.
 
@@ -789,19 +787,19 @@ This function returns a tensor that is the result of vertically stacking the two
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:vstack("{\"type\": \"float32\", \"shape\": [2, 2], \"data\": [1, 2, 3, 4]}"^^dt:NumericDataTensor, "{\"type\": \"float32\", \"shape\": [2, 2], \"data\": [5, 6, 7, 8]}"^^dt:NumericDataTensor)
+    tensor:vstack("{\"type\": \"float32\", \"shape\": [2, 2], \"data\": [1, 2, 3, 4]}"^^tensor:NumericDataTensor, "{\"type\": \"float32\", \"shape\": [2, 2], \"data\": [5, 6, 7, 8]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [4, 2], \"data\": [1, 2, 3, 4, 5, 6, 7, 8]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [4, 2], \"data\": [1, 2, 3, 4, 5, 6, 7, 8]}"^^tensor:NumericDataTensor
     ```
 
 ### 4.5. Reduction Functions
 
-#### `dtf:all`
-[xsd:boolean](http://www.w3.org/2001/XMLSchema#boolean) **dtf:all** ([dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) *term_1*)
+#### `tensor:all`
+[xsd:boolean](http://www.w3.org/2001/XMLSchema#boolean) **tensor:all** ([tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) *term_1*)
 
 This function checks if all elements in the boolean tensor are true. Returns a single boolean value.
 
@@ -810,7 +808,7 @@ This function checks if all elements in the boolean tensor are true. Returns a s
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:all("{\"shape\": [2], \"data\": [true, true]}"^^dt:BooleanDataTensor)  
+    tensor:all("{\"shape\": [2], \"data\": [true, true]}"^^tensor:BooleanDataTensor)  
     ```
 
     returns
@@ -821,8 +819,8 @@ This function checks if all elements in the boolean tensor are true. Returns a s
 
 ---
 
-#### `dtf:any`
-[dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) **dtf:any** ([dt:BooleanDataTensor](https://w3id.org/rdf-tensor/datatypes#BooleanDataTensor) *term_1*)
+#### `tensor:any`
+[tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) **tensor:any** ([tensor:BooleanDataTensor](https://w3id.org/rdf-tensor/vocab#BooleanDataTensor) *term_1*)
 
 This function checks if any element in the boolean tensor is true. Returns a single boolean value.
 
@@ -831,7 +829,7 @@ This function checks if any element in the boolean tensor is true. Returns a sin
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:any("{\"shape\": [2], \"data\": [false, true]}"^^dt:BooleanDataTensor)
+    tensor:any("{\"shape\": [2], \"data\": [false, true]}"^^tensor:BooleanDataTensor)
     ```
 
     returns
@@ -842,9 +840,9 @@ This function checks if any element in the boolean tensor is true. Returns a sin
 
 ---
 
-#### `dtf:avg`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:avg** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
-[xsd:double](http://www.w3.org/2001/XMLSchema#double) **dtf:avg** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+#### `tensor:avg`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:avg** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
+[xsd:double](http://www.w3.org/2001/XMLSchema#double) **tensor:avg** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
 This function computes the average along the specified axis. If the axis is negative, the average is calculated over the entire tensor. It returns a reduced tensor or a scalar.
 
@@ -853,20 +851,20 @@ This function computes the average along the specified axis. If the axis is nega
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:avg(1, "{\"type\": \"float32\", \"shape\": [2,2], \"data\": [1, 2, 3, 4]}"^^dt:NumericDataTensor)
+    tensor:avg(1, "{\"type\": \"float32\", \"shape\": [2,2], \"data\": [1, 2, 3, 4]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [2], \"data\": [1.5, 3.5]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [2], \"data\": [1.5, 3.5]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:sum`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:sum** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
-[xsd:double](http://www.w3.org/2001/XMLSchema#double) **dtf:sum** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+#### `tensor:sum`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:sum** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
+[xsd:double](http://www.w3.org/2001/XMLSchema#double) **tensor:sum** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
 This function computes the sum along the specified axis. If the axis is negative, the sum is calculated over the entire tensor. It returns a reduced tensor or a scalar.
 
@@ -875,21 +873,21 @@ This function computes the sum along the specified axis. If the axis is negative
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:sum(1, "{\"type\": \"float32\", \"shape\": [2,2], \"data\": [1, 2, 3, 4]}"^^dt:NumericDataTensor)
+    tensor:sum(1, "{\"type\": \"float32\", \"shape\": [2,2], \"data\": [1, 2, 3, 4]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [2], \"data\": [3, 7]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [2], \"data\": [3, 7]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:max`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:max** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+#### `tensor:max`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:max** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
-[xsd:double](http://www.w3.org/2001/XMLSchema#double) **dtf:max** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+[xsd:double](http://www.w3.org/2001/XMLSchema#double) **tensor:max** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
 This function computes the maximum along the specified axis. If the axis is negative, the maximum is calculated over the entire tensor. It returns a reduced tensor or a scalar.
 
@@ -898,21 +896,21 @@ This function computes the maximum along the specified axis. If the axis is nega
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:max(1, "{\"type\": \"float32\", \"shape\": [2,2], \"data\": [1, 5, 2, 4]}"^^dt:NumericDataTensor)
+    tensor:max(1, "{\"type\": \"float32\", \"shape\": [2,2], \"data\": [1, 5, 2, 4]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [2], \"data\": [5, 4]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [2], \"data\": [5, 4]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:median`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:median** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+#### `tensor:median`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:median** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
-[xsd:double](http://www.w3.org/2001/XMLSchema#double) **dtf:median** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+[xsd:double](http://www.w3.org/2001/XMLSchema#double) **tensor:median** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
 This function computes the median along the specified axis. If the axis is negative, the median is calculated over the entire tensor. It returns a reduced tensor or a scalar.
 
@@ -921,21 +919,21 @@ This function computes the median along the specified axis. If the axis is negat
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:median(1, "{\"type\": \"float32\", \"shape\": [1, 3], \"data\": [7, 1, 3]}"^^dt:NumericDataTensor)
+    tensor:median(1, "{\"type\": \"float32\", \"shape\": [1, 3], \"data\": [7, 1, 3]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [1], \"data\": [3]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [1], \"data\": [3]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:min`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:min** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+#### `tensor:min`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:min** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
-[xsd:double](http://www.w3.org/2001/XMLSchema#double) **dtf:min** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+[xsd:double](http://www.w3.org/2001/XMLSchema#double) **tensor:min** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
 This function computes the minimum along the specified axis. If the axis is negative, the minimum is calculated over the entire tensor. It returns a reduced tensor or a scalar.
 
@@ -944,21 +942,21 @@ This function computes the minimum along the specified axis. If the axis is nega
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:min(1, "{\"type\": \"float32\", \"shape\": [1,3], \"data\": [7, 1, 3]}"^^dt:NumericDataTensor)
+    tensor:min(1, "{\"type\": \"float32\", \"shape\": [1,3], \"data\": [7, 1, 3]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [1], \"data\": [1]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [1], \"data\": [1]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:std`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:std** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+#### `tensor:std`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:std** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
-[xsd:double](http://www.w3.org/2001/XMLSchema#double) **dtf:std** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+[xsd:double](http://www.w3.org/2001/XMLSchema#double) **tensor:std** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
 This function computes the standard deviation along the specified axis. If the axis is negative, the standard deviation is calculated over the entire tensor. It returns a reduced tensor or a scalar.
 
@@ -967,21 +965,21 @@ This function computes the standard deviation along the specified axis. If the a
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:std(1, "{\"type\": \"float32\", \"shape\": [1,3], \"data\": [1, 2, 3]}"^^dt:NumericDataTensor)
+    tensor:std(1, "{\"type\": \"float32\", \"shape\": [1,3], \"data\": [1, 2, 3]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [1], \"data\": [0.8165]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [1], \"data\": [0.8165]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:var`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:var** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+#### `tensor:var`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:var** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
-[xsd:double](http://www.w3.org/2001/XMLSchema#double) **dtf:var** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+[xsd:double](http://www.w3.org/2001/XMLSchema#double) **tensor:var** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
 This function computes the variance along the specified axis. If the axis is negative, the variance is calculated over the entire tensor. It returns a reduced tensor or a scalar.
 
@@ -990,21 +988,21 @@ This function computes the variance along the specified axis. If the axis is neg
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:var(1, "{\"type\": \"float32\", \"shape\": [1,3], \"data\": [1, 2, 3]}"^^dt:NumericDataTensor)
+    tensor:var(1, "{\"type\": \"float32\", \"shape\": [1,3], \"data\": [1, 2, 3]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [1], \"data\": [0.6667]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [1], \"data\": [0.6667]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:norm1`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:norm1** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+#### `tensor:norm1`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:norm1** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
-[xsd:double](http://www.w3.org/2001/XMLSchema#double) **dtf:norm1** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+[xsd:double](http://www.w3.org/2001/XMLSchema#double) **tensor:norm1** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
 This function computes the L1 norm (sum of absolute values) along the specified axis. If the axis is negative, the L1 norm (sum of absolute values) is calculated over the entire tensor. It returns a reduced tensor or a scalar.
 
@@ -1013,21 +1011,21 @@ This function computes the L1 norm (sum of absolute values) along the specified 
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:norm1(1, "{\"type\": \"float32\", \"shape\": [2,2], \"data\": [1, -1, -2, 2]}"^^dt:NumericDataTensor)  
+    tensor:norm1(1, "{\"type\": \"float32\", \"shape\": [2,2], \"data\": [1, -1, -2, 2]}"^^tensor:NumericDataTensor)  
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [2], \"data\": [2, 4]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [2], \"data\": [2, 4]}"^^tensor:NumericDataTensor
     ```
 
 ---
 
-#### `dtf:norm2`
-[dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) **dtf:norm2** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+#### `tensor:norm2`
+[tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) **tensor:norm2** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
-[xsd:double](http://www.w3.org/2001/XMLSchema#double) **dtf:norm1** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*)
+[xsd:double](http://www.w3.org/2001/XMLSchema#double) **tensor:norm1** ([xsd:integer](http://www.w3.org/2001/XMLSchema#integer) *axis*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*)
 
 This function computes the L2 norm (Euclidean norm) along the specified axis. If the axis is negative, the L2 norm (Euclidean norm) is calculated over the entire tensor. It returns a reduced tensor or a scalar.
 
@@ -1036,20 +1034,20 @@ This function computes the L2 norm (Euclidean norm) along the specified axis. If
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:norm2(1, "{\"type\": \"float32\", \"shape\": [2,2], \"data\": [3, 4, 6, 8]}"^^dt:NumericDataTensor)
+    tensor:norm2(1, "{\"type\": \"float32\", \"shape\": [2,2], \"data\": [3, 4, 6, 8]}"^^tensor:NumericDataTensor)
     ```
 
     returns
 
     ```turtle
-    "{\"type\": \"float32\", \"shape\": [2], \"data\": [5, 10]}"^^dt:NumericDataTensor
+    "{\"type\": \"float32\", \"shape\": [2], \"data\": [5, 10]}"^^tensor:NumericDataTensor
     ```
 
 
 ### 4.6. Similarity Functions
 
-#### `dtf:cosineSimilarity`
-[xsd:double](http://www.w3.org/2001/XMLSchema#double) **dtf:cosineSimilarity** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_2*)
+#### `tensor:cosineSimilarity`
+[xsd:double](http://www.w3.org/2001/XMLSchema#double) **tensor:cosineSimilarity** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_2*)
 
 This function computes the cosine similarity between two numerical tensors. Returns a numeric scalar value.
 
@@ -1058,7 +1056,7 @@ This function computes the cosine similarity between two numerical tensors. Retu
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:cosineSimilarity( "{\"type\": \"float32\", \"shape\": [3], \"data\": [1, 0, 1]}"^^dt:NumericDataTensor, "{\"type\": \"float32\", \"shape\": [3], \"data\": [1, 1, 0]}"^^dt:NumericDataTensor)
+    tensor:cosineSimilarity( "{\"type\": \"float32\", \"shape\": [3], \"data\": [1, 0, 1]}"^^tensor:NumericDataTensor, "{\"type\": \"float32\", \"shape\": [3], \"data\": [1, 1, 0]}"^^tensor:NumericDataTensor)
     ```
 
     returns
@@ -1069,8 +1067,8 @@ This function computes the cosine similarity between two numerical tensors. Retu
 
 ---
 
-#### `dtf:euclideanDistance`
-[xsd:double](http://www.w3.org/2001/XMLSchema#double) **dtf:euclideanDistance** ([dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_1*, [dt:NumericDataTensor](https://w3id.org/rdf-tensor/datatypes#NumericDataTensor) *term_2*)
+#### `tensor:euclideanDistance`
+[xsd:double](http://www.w3.org/2001/XMLSchema#double) **tensor:euclideanDistance** ([tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_1*, [tensor:NumericDataTensor](https://w3id.org/rdf-tensor/vocab#NumericDataTensor) *term_2*)
 
 This function computes the Euclidean distance between two numerical tensors. Returns a numeric scalar value.
 
@@ -1079,7 +1077,7 @@ This function computes the Euclidean distance between two numerical tensors. Ret
     Evaluating the SPARQL expression
 
     ```sparql
-    dtf:euclideanDistance("{\"type\": \"float32\", \"shape\": [2], \"data\": [3, 4]}"^^dt:NumericDataTensor, "{\"type\": \"float32\", \"shape\": [2], \"data\": [0, 0]}"^^dt:NumericDataTensor)
+    tensor:euclideanDistance("{\"type\": \"float32\", \"shape\": [2], \"data\": [3, 4]}"^^tensor:NumericDataTensor, "{\"type\": \"float32\", \"shape\": [2], \"data\": [0, 0]}"^^tensor:NumericDataTensor)
     ```
 
     returns
@@ -1092,26 +1090,26 @@ This function computes the Euclidean distance between two numerical tensors. Ret
 
 The following aggregation functions are implemented as SPARQL extension aggregates. Each function operates over NumericDataTensor values and returns a NumericDataTensor with the most precise type used within each group. These functions do not support the DISTINCT modifier.
 
-### `dta:sum`
-- **IRI:** `https://w3id.org/rdf-tensor/aggregates#sum`
+### `tensor:sum`
+- **IRI:** `https://w3id.org/rdf-tensor/vocab#sum`
 - **Description:** Sums grouped numeric tensors element-wise.
 - **Input:** A group of `NumericDataTensor` values.
 - **Output:** A `NumericDataTensor` representing the element-wise sum of all tensors in the group.
 
-### `dta:avg`
-- **IRI:** `https://w3id.org/rdf-tensor/aggregates#avg`
+### `tensor:avg`
+- **IRI:** `https://w3id.org/rdf-tensor/vocab#avg`
 - **Description:** Computes the element-wise average of grouped tensors.
 - **Input:** A group of `NumericDataTensor` values.
 - **Output:** A `NumericDataTensor` representing the average tensor.
 
-### `dta:var`
-- **IRI:** `https://w3id.org/rdf-tensor/aggregates#var`
+### `tensor:var`
+- **IRI:** `https://w3id.org/rdf-tensor/vocab#var`
 - **Description:** Calculates the element-wise variance across grouped tensors.
 - **Input:** A group of `NumericDataTensor` values.
 - **Output:** A `NumericDataTensor` representing the variance tensor.
 
-### `dta:std`
-- **IRI:** `https://w3id.org/rdf-tensor/aggregates#std`
+### `tensor:std`
+- **IRI:** `https://w3id.org/rdf-tensor/vocab#std`
 - **Description:** Computes the element-wise standard deviation across grouped tensors.
 - **Input:** A group of `NumericDataTensor` values.
 - **Output:** A `NumericDataTensor` representing the standard deviation tensor.

--- a/ontology/aggregates.ttl
+++ b/ontology/aggregates.ttl
@@ -2,37 +2,29 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix dta: <https://w3id.org/rdf-tensor/aggregates#> .
+@prefix tensor: <https://w3id.org/rdf-tensor/vocab#> .
 @prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
 
-dta:sum a sd:Aggregate ;
+tensor:sum a sd:Aggregate ;
     dc:date "2024-07-28"^^xsd:date ;
     rdfs:label "Sum" ;
     rdfs:comment "Sums grouped tensors"@en ;
-    dc:description "Sums grouped tensors"@en ;
-    skos:definition "Sums grouped tensors"@en ;
     dc:creator "Piotr Marciniak" .
 
-dta:avg a sd:Aggregate ;
+tensor:avg a sd:Aggregate ;
     dc:date "2024-07-28"^^xsd:date ;
     rdfs:label "Average" ;
     rdfs:comment "Averages grouped tensors by summing them elementwise and dividing the result by the number of tensors"@en ;
-    dc:description "Averages grouped tensors by summing them elementwise and dividing the result by the number of tensors"@en ;
-    skos:definition "Averages grouped tensors by summing them elementwise and dividing the result by the number of tensors"@en ;
     dc:creator "Piotr Marciniak" .
 
-dta:var a sd:Aggregate ;
+tensor:var a sd:Aggregate ;
     dc:date "2024-07-28"^^xsd:date ;
     rdfs:label "Variance" ;
     rdfs:comment "Calculates the variance of grouped tensors"@en ;
-    dc:description "Calculates the variance of grouped tensors"@en ;
-    skos:definition "Calculates the variance of grouped tensors"@en ;
     dc:creator "Piotr Marciniak" .
 
-dta:std a sd:Aggregate ;
+tensor:std a sd:Aggregate ;
     dc:date "2024-07-28"^^xsd:date ;
     rdfs:label "Standard Deviation" ;
     rdfs:comment "Calculates the standard deviation of grouped tensors"@en ;
-    dc:description "Calculates the standard deviation of grouped tensors"@en ;
-    skos:definition "Calculates the standard deviation of grouped tensors"@en ;
     dc:creator "Piotr Marciniak" .

--- a/ontology/datatypes.ttl
+++ b/ontology/datatypes.ttl
@@ -2,21 +2,17 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix dt: <https://w3id.org/rdf-tensor/datatypes#> .
+@prefix tensor: <https://w3id.org/rdf-tensor/vocab#> .
 
-dt:NumericDataTensor  a rdfs:Datatype ;
+tensor:NumericDataTensor  a rdfs:Datatype ;
   dc:date "2024-07-28"^^xsd:date ;
   rdfs:label "Numeric Data Tensor" ;
   rdfs:comment "The datatype for a tensor representing numeric data."@en ;
-  dc:description "The datatype for a tensor representing numeric data."@en ;
-  skos:definition "The datatype for a tensor representing numeric data."@en ;
   dc:creator "Piotr Marciniak" .
 
-dt:BooleanDataTensor  a rdfs:Datatype ;
+tensor:BooleanDataTensor  a rdfs:Datatype ;
   dc:date "2024-07-28"^^xsd:date ;
   rdfs:label "Boolean Data Tensor" ;
   rdfs:comment "The datatype for a tensor representing boolean data."@en ;
-  dc:description "The datatype for a tensor representing boolean data."@en ;
-  skos:definition "The datatype for a tensor representing boolean data."@en ;
   dc:creator "Piotr Marciniak" .
     

--- a/ontology/functions.ttl
+++ b/ontology/functions.ttl
@@ -2,258 +2,185 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix dtf: <https://w3id.org/rdf-tensor/functions#> .
+@prefix tensor: <https://w3id.org/rdf-tensor/vocab#> .
 @prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
 
-dtf:cos a sd:Function ;
-    dc:date "2024-07-28"^^xsd:date ;
+tensor:cos a sd:Function ;
     rdfs:label "Cosine" ;
     rdfs:comment "Computes the cosine of each element in the numerical tensor."@en ;
-    dc:description "Computes the cosine of each element in the numerical tensor."@en ;
-    skos:definition "Computes the cosine of each element in the numerical tensor."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:exp a sd:Function ;
+tensor:exp a sd:Function ;
     rdfs:label "Exponential" ;
     rdfs:comment "Applies the exponential function to each element."@en ;
-    dc:description "Applies the exponential function to each element."@en ;
-    skos:definition "Applies the exponential function to each element."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:log a sd:Function ;
+tensor:log a sd:Function ;
     rdfs:label "Natural Logarithm" ;
     rdfs:comment "Applies the natural logarithm to each element."@en ;
-    dc:description "Applies the natural logarithm to each element."@en ;
-    skos:definition "Applies the natural logarithm to each element."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:logp a sd:Function ;
+tensor:logp a sd:Function ;
     rdfs:label "Logarithm with Base p" ;
     rdfs:comment "Applies logarithm with specified base p."@en ;
-    dc:description "Applies logarithm with specified base p."@en ;
-    skos:definition "Applies logarithm with specified base p."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:poly a sd:Function ;
+tensor:poly a sd:Function ;
     rdfs:label "Polynomial Power" ;
     rdfs:comment "Raises each element to a specified power."@en ;
-    dc:description "Raises each element to a specified power."@en ;
-    skos:definition "Raises each element to a specified power."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:scale a sd:Function ;
+tensor:scale a sd:Function ;
     rdfs:label "Scale" ;
     rdfs:comment "Scales tensor elements by a constant."@en ;
-    dc:description "Scales tensor elements by a constant."@en ;
-    skos:definition "Scales tensor elements by a constant."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:sin a sd:Function ;
+tensor:sin a sd:Function ;
     rdfs:label "Sine" ;
     rdfs:comment "Computes the sine of each element in the numerical tensor."@en ;
-    dc:description "Computes the sine of each element in the numerical tensor."@en ;
-    skos:definition "Computes the sine of each element in the numerical tensor."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:abs a sd:Function ;
+tensor:abs a sd:Function ;
     rdfs:label "Absolute Value" ;
     rdfs:comment "Applies absolute value to each element."@en ;
-    dc:description "Applies absolute value to each element."@en ;
-    skos:definition "Applies absolute value to each element."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:not a sd:Function ;
+tensor:not a sd:Function ;
     rdfs:label "Logical NOT" ;
     rdfs:comment "Computes the logical negation of each boolean tensor element."@en ;
-    dc:description "Computes the logical negation of each boolean tensor element."@en ;
-    skos:definition "Computes the logical negation of each boolean tensor element."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:add a sd:Function ;
+tensor:add a sd:Function ;
     rdfs:label "Addition" ;
     rdfs:comment "Adds two numerical tensors element-wise."@en ;
-    dc:description "Adds two numerical tensors element-wise."@en ;
-    skos:definition "Adds two numerical tensors element-wise."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:subtract a sd:Function ;
+tensor:subtract a sd:Function ;
     rdfs:label "Subtraction" ;
     rdfs:comment "Subtracts the second numerical tensor from the first element-wise."@en ;
-    dc:description "Subtracts the second numerical tensor from the first element-wise."@en ;
-    skos:definition "Subtracts the second numerical tensor from the first element-wise."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:multiply a sd:Function ;
+tensor:multiply a sd:Function ;
     rdfs:label "Multiplication" ;
     rdfs:comment "Multiplies two numerical tensors element-wise."@en ;
-    dc:description "Multiplies two numerical tensors element-wise."@en ;
-    skos:definition "Multiplies two numerical tensors element-wise."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:divide a sd:Function ;
+tensor:divide a sd:Function ;
     rdfs:label "Division" ;
     rdfs:comment "Divides the first numerical tensor by the second element-wise."@en ;
-    dc:description "Divides the first numerical tensor by the second element-wise."@en ;
-    skos:definition "Divides the first numerical tensor by the second element-wise."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:eq a sd:Function ;
+tensor:eq a sd:Function ;
     rdfs:label "Equality Check" ;
     rdfs:comment "Checks if elements in two tensors are equal."@en ;
-    dc:description "Checks if elements in two tensors are equal."@en ;
-    skos:definition "Checks if elements in two tensors are equal."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:neq a sd:Function ;
+tensor:neq a sd:Function ;
     rdfs:label "Inequality Check" ;
     rdfs:comment "Checks if elements in two tensors are not equal."@en ;
-    dc:description "Checks if elements in two tensors are not equal."@en ;
-    skos:definition "Checks if elements in two tensors are not equal."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:and a sd:Function ;
+tensor:and a sd:Function ;
     rdfs:label "Logical AND" ;
     rdfs:comment "Performs element-wise logical AND on boolean tensors."@en ;
-    dc:description "Performs element-wise logical AND on boolean tensors."@en ;
-    skos:definition "Performs element-wise logical AND on boolean tensors."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:or a sd:Function ;
+tensor:or a sd:Function ;
     rdfs:label "Logical OR" ;
     rdfs:comment "Performs element-wise logical OR on boolean tensors."@en ;
-    dc:description "Performs element-wise logical OR on boolean tensors."@en ;
-    skos:definition "Performs element-wise logical OR on boolean tensors."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:gt a sd:Function ;
+tensor:gt a sd:Function ;
     rdfs:label "Greater Than" ;
     rdfs:comment "Compares if first tensor is greater than the second element-wise."@en ;
-    dc:description "Compares if first tensor is greater than the second element-wise."@en ;
-    skos:definition "Compares if first tensor is greater than the second element-wise."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:lt a sd:Function ;
+tensor:lt a sd:Function ;
     rdfs:label "Less Than" ;
     rdfs:comment "Compares if first tensor is less than the second element-wise."@en ;
-    dc:description "Compares if first tensor is less than the second element-wise."@en ;
-    skos:definition "Compares if first tensor is less than the second element-wise."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:getSubDT a sd:Function ;
+tensor:getSubDT a sd:Function ;
     rdfs:label "Get Sub-Tensor" ;
     rdfs:comment "Extracts a sub-tensor based on an index or mask tensor."@en ;
-    dc:description "Extracts a sub-tensor based on an index or mask tensor."@en ;
-    skos:definition "Extracts a sub-tensor based on an index or mask tensor."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:concat a sd:Function ;
+tensor:concat a sd:Function ;
     rdfs:label "Concatenate Tensors" ;
     rdfs:comment "Concatenates two tensors optionally along a specified dimension."@en ;
-    dc:description "Concatenates two tensors optionally along a specified dimension."@en ;
-    skos:definition "Concatenates two tensors optionally along a specified dimension."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:hstack a sd:Function ;
+tensor:hstack a sd:Function ;
     rdfs:label "Horizontal Stack" ;
     rdfs:comment "Stacks two tensors horizontally (along axis 1)."@en ;
-    dc:description "Stacks two tensors horizontally (along axis 1)."@en ;
-    skos:definition "Stacks two tensors horizontally (along axis 1)."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:vstack a sd:Function ;
+tensor:vstack a sd:Function ;
     rdfs:label "Vertical Stack" ;
     rdfs:comment "Stacks two tensors vertically (along axis 0)."@en ;
-    dc:description "Stacks two tensors vertically (along axis 0)."@en ;
-    skos:definition "Stacks two tensors vertically (along axis 0)."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:all a sd:Function ;
+tensor:all a sd:Function ;
     rdfs:label "All True" ;
     rdfs:comment "Checks whether all elements in a boolean tensor are true."@en ;
-    dc:description "Checks whether all elements in a boolean tensor are true."@en ;
-    skos:definition "Checks whether all elements in a boolean tensor are true."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:any a sd:Function ;
+tensor:any a sd:Function ;
     rdfs:label "Any True" ;
     rdfs:comment "Checks whether any element in a boolean tensor is true."@en ;
-    dc:description "Checks whether any element in a boolean tensor is true."@en ;
-    skos:definition "Checks whether any element in a boolean tensor is true."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:avg a sd:Function ;
+tensor:avg a sd:Function ;
     rdfs:label "Average" ;
     rdfs:comment "Computes the average along a specified axis."@en ;
-    dc:description "Computes the average along a specified axis."@en ;
-    skos:definition "Computes the average along a specified axis."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:sum a sd:Function ;
+tensor:sum a sd:Function ;
     rdfs:label "Sum" ;
     rdfs:comment "Computes the sum along a specified axis."@en ;
-    dc:description "Computes the sum along a specified axis."@en ;
-    skos:definition "Computes the sum along a specified axis."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:max a sd:Function ;
+tensor:max a sd:Function ;
     rdfs:label "Maximum" ;
     rdfs:comment "Computes the maximum along a specified axis."@en ;
-    dc:description "Computes the maximum along a specified axis."@en ;
-    skos:definition "Computes the maximum along a specified axis."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:median a sd:Function ;
+tensor:median a sd:Function ;
     rdfs:label "Median" ;
     rdfs:comment "Computes the median along a specified axis."@en ;
-    dc:description "Computes the median along a specified axis."@en ;
-    skos:definition "Computes the median along a specified axis."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:min a sd:Function ;
+tensor:min a sd:Function ;
     rdfs:label "Minimum" ;
     rdfs:comment "Computes the minimum along a specified axis."@en ;
-    dc:description "Computes the minimum along a specified axis."@en ;
-    skos:definition "Computes the minimum along a specified axis."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:std a sd:Function ;
+tensor:std a sd:Function ;
     rdfs:label "Standard Deviation" ;
     rdfs:comment "Computes the standard deviation along a specified axis."@en ;
-    dc:description "Computes the standard deviation along a specified axis."@en ;
-    skos:definition "Computes the standard deviation along a specified axis."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:var a sd:Function ;
+tensor:var a sd:Function ;
     rdfs:label "Variance" ;
     rdfs:comment "Computes the variance along a specified axis."@en ;
-    dc:description "Computes the variance along a specified axis."@en ;
-    skos:definition "Computes the variance along a specified axis."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:norm1 a sd:Function ;
+tensor:norm1 a sd:Function ;
     rdfs:label "L1 Norm" ;
     rdfs:comment "Computes the L1 norm along a specified axis."@en ;
-    dc:description "Computes the L1 norm along a specified axis."@en ;
-    skos:definition "Computes the L1 norm along a specified axis."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:norm2 a sd:Function ;
+tensor:norm2 a sd:Function ;
     rdfs:label "L2 Norm" ;
     rdfs:comment "Computes the L2 norm along a specified axis."@en ;
-    dc:description "Computes the L2 norm along a specified axis."@en ;
-    skos:definition "Computes the L2 norm along a specified axis."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:cosineSimilarity a sd:Function ;
+tensor:cosineSimilarity a sd:Function ;
     rdfs:label "Cosine Similarity" ;
     rdfs:comment "Computes the cosine similarity between two numerical tensors."@en ;
-    dc:description "Computes the cosine similarity between two numerical tensors."@en ;
-    skos:definition "Computes the cosine similarity between two numerical tensors."@en ;
     dc:creator "Piotr Marciniak" .
 
-dtf:euclideanDistance a sd:Function ;
+tensor:euclideanDistance a sd:Function ;
     rdfs:label "Euclidean Distance" ;
     rdfs:comment "Computes the Euclidean distance between two numerical tensors."@en ;
-    dc:description "Computes the Euclidean distance between two numerical tensors."@en ;
-    skos:definition "Computes the Euclidean distance between two numerical tensors."@en ;
     dc:creator "Piotr Marciniak" .


### PR DESCRIPTION
Closes: #1 

This merges all ontology prefixes into one (`tensor:`), which should be way easier to use and less error-prone.

I've also removed a bunch of redundant metadata from the ontology.