### PR TITLE
Add resize and resizeByScales functions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -858,6 +858,221 @@ The result of the function is a tensor of the same shape as the input tensor, wh
 
 ---
 
+#### `tensor:resize`
+
+??? info "Resizing functions"
+
+    The functions starting with `tensor:resize` resize a tensor to a different shape by interpolating values. These functions both accept a common set of optional configuration arguments dispatched left-to-right by XSD type and (for mode-dependent arguments) by the value of `mode`:
+
+    1. If the next argument is `xsd:string`, it is taken as the interpolation _mode_. Default: `"linear"`.
+    2. If the next argument is `xsd:string`, it is taken as the _coordinateTransformationMode_. Default: `"half_pixel"`.
+    3. If _mode_ is `"nearest"` and the next argument is `xsd:string`, it is taken as the _nearestMode_. Default: `"round_prefer_floor"`. Consumed only when _mode_ is `"nearest"`.
+    4. If _mode_ is `"cubic"` and the next argument is `xsd:double`, it is taken as _cubicCoeffA_. Default: `-0.75`. Consumed only when _mode_ is `"cubic"`.
+    5. If the next argument is `xsd:boolean`, it is taken as the _antialias_ flag. Default: `false`.
+    6. All remaining arguments before the trailing tensor form the shape specification (integer _sizes_ for `tensor:resize`, double _scales_ for `tensor:resizeByScales`).
+
+    ??? info "Validation errors for resizing functions"
+
+        Implementations must raise a query-evaluation error if:
+
+        - _antialias_ is `true` and _mode_ is `"nearest"`.
+        - _coordinateTransformationMode_ is `"tf_crop_and_resize"`. This mode is incompatible with the semantics of these functions and is not supported.
+        - _nearestMode_ is provided but _mode_ is not `"nearest"`.
+        - _cubicCoeffA_ is provided but _mode_ is not `"cubic"`.
+        - The number of sizes/scales does not equal the rank of the input tensor.
+        - Any size is less than or equal to `0`, or any scale is less than or equal to `0`.
+
+    ??? info "Dispatching _cubicCoeffA_ in `tensor:resizeByScales`"
+
+        In `tensor:resizeByScales`, both _cubicCoeffA_ and _scales_ are `xsd:double`, so type alone cannot disambiguate them. Dispatch for _cubicCoeffA_ in this function is resolved by argument count: when _mode_ is `"cubic"`, if the number of `xsd:double` arguments remaining before the trailing tensor exceeds the rank of _term_1_ by one, the first such argument is taken as _cubicCoeffA_; otherwise _cubicCoeffA_ defaults to `-0.75`.
+
+        For example, given a rank-4 tensor, `tensor:resizeByScales("cubic", "half_pixel", -0.5, 1.0, 1.0, 2.0, 2.0, ?t)` provides 5 doubles (1 excess), then first is _cubicCoeffA_; `tensor:resizeByScales("cubic", "half_pixel", 1.0, 1.0, 2.0, 2.0, ?t)` provides 4 doubles (none excess), then _cubicCoeffA_ defaults.
+
+
+[tensor:DataTensor](https://w3id.org/rdf-tensor/vocab#DataTensor) **tensor:resize** ([xsd:string _mode_], [xsd:string _coordinateTransformationMode_], [xsd:string _nearestMode_], [xsd:double _cubicCoeffA_], [xsd:boolean _antialias_], [xsd:integer](http://www.w3.org/2001/XMLSchema#integer) ... _sizes_, [tensor:DataTensor](https://w3id.org/rdf-tensor/vocab#DataTensor) _term_1_)
+
+The result of the function is a tensor resized to the exact shape given by _sizes_, interpolating elements of _term_1_ according to _mode_ and _coordinateTransformationMode_. The number of _sizes_ arguments must equal the rank of _term_1_.
+
+Admissible values for the configuration arguments:
+
+- _mode_: `"nearest"`, `"linear"` (default), or `"cubic"`. The `"linear"` mode performs N-linear interpolation (e.g., bilinear for 2-D); `"cubic"` performs N-cubic.
+- _coordinateTransformationMode_: `"half_pixel"` (default), `"half_pixel_symmetric"`, `"pytorch_half_pixel"`, `"align_corners"`, or `"asymmetric"`.
+- _nearestMode_: `"round_prefer_floor"` (default), `"round_prefer_ceil"`, `"floor"`, or `"ceil"`.
+- _cubicCoeffA_: any `xsd:double`. Common values are `-0.5` (TensorFlow-compatible) and `-0.75` (PyTorch-compatible, default).
+- _antialias_: when `true`, the linear and cubic kernels are stretched by `max(1, 1/scale)` per dimension being downscaled. Ignored by `"nearest"`.
+
+!!! example "Example 1"
+
+    Evaluating the SPARQL expression (nearest-neighbour 2x upscaling)
+
+    ```sparql
+    tensor:resize(
+        "nearest", "asymmetric",
+        1, 1, 4, 4,
+        "{\"type\":\"int32\",\"shape\":[1,1,2,2],\"data\":[1, 2, 3, 4]}"^^tensor:DataTensor
+    )
+    ```
+
+    returns
+
+    ```turtle
+    "{\"type\": \"int32\", \"shape\": [1, 1, 4, 4], \"data\": [1, 1, 2, 2, 1, 1, 2, 2, 3, 3, 4, 4, 3, 3, 4, 4]}"^^tensor:DataTensor
+    ```
+
+!!! example "Example 2"
+
+    Evaluating the SPARQL expression (nearest-neighbour 0.5x downscaling)
+
+    ```sparql
+    tensor:resize(
+        "nearest", "asymmetric",
+        1, 1, 2, 2,
+        "{\"type\":\"int32\",\"shape\":[1,1,4,4],\"data\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]}"^^tensor:DataTensor
+    )
+    ```
+
+    returns
+
+    ```turtle
+    "{\"type\": \"int32\", \"shape\": [1, 1, 2, 2], \"data\": [1, 3, 9, 11]}"^^tensor:DataTensor
+    ```
+
+!!! example "Example 3"
+
+    Evaluating the SPARQL expression (bilinear upscaling, all config defaults)
+
+    ```sparql
+    tensor:resize(
+        1, 1, 4, 4,
+        "{\"type\":\"float32\",\"shape\":[1,1,2,2],\"data\":[1, 2, 3, 4]}"^^tensor:DataTensor
+    )
+    ```
+
+    returns a `[1, 1, 4, 4]` `float32` tensor bilinearly interpolated from the input.
+
+!!! example "Example 4"
+
+    Evaluating the SPARQL expression (anti-aliased bicubic downscaling, TensorFlow-compatible coefficient)
+
+    ```sparql
+    tensor:resize(
+        "cubic", "half_pixel", -0.5, true,
+        1, 1, 3, 3,
+        "{\"type\":\"float32\",\"shape\":[1,1,8,8],\"data\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64]}"^^tensor:DataTensor
+    )
+    ```
+
+    returns a `[1, 1, 3, 3]` `float32` tensor produced by bicubic downsampling with the `a = -0.5` kernel and an antialiasing prefilter.
+
+??? note "ONNX definition of this function"
+
+    === "Model description"
+
+        Model inputs and outputs:
+
+        - `input1`: A tensor of any shape and <input_type> type.
+        - `output1`: A tensor of <input_type> type with shape given by the _sizes_ arguments.
+
+        Model variables:
+
+        - `input_type`: The data type of the input tensor, which can be any supported type.
+        - `mode_value`: The resolved value of the _mode_ argument, or `"linear"` if omitted.
+        - `coord_transform_mode_value`: The resolved value of the _coordinateTransformationMode_ argument, or `"half_pixel"` if omitted.
+        - `nearest_mode_value`: The resolved value of the _nearestMode_ argument, or `"round_prefer_floor"` if omitted.
+        - `cubic_coeff_a_value`: The resolved value of _cubicCoeffA_ as FLOAT, or `-0.75` if omitted.
+        - `antialias_value`: `1` if _antialias_ is `true`, `0` otherwise (default).
+        - `sizes_length`: The number of dimensions in the output tensor, equal to the rank of `input1` and the count of integer _sizes_ arguments.
+        - `sizes_values`: The target sizes, one per dimension, as INT64 values.
+
+    === "Model definition"
+
+        ```pbtxt title="tensor_resize_model.pbtxt"
+        {% include "./onnx/tensor_resize_model.pbtxt" %}
+        ```
+
+---
+
+#### `tensor:resizeByScales`
+
+[tensor:DataTensor](https://w3id.org/rdf-tensor/vocab#DataTensor) **tensor:resizeByScales** ([xsd:string _mode_], [xsd:string _coordinateTransformationMode_], [xsd:string _nearestMode_], [xsd:double _cubicCoeffA_], [xsd:boolean _antialias_], [xsd:double](http://www.w3.org/2001/XMLSchema#double) ... _scales_, [tensor:DataTensor](https://w3id.org/rdf-tensor/vocab#DataTensor) _term_1_)
+
+The result of the function is a tensor where each dimension is scaled by the corresponding factor in _scales_. The output size on dimension _i_ is `floor(input_size[i] * scales[i])`. The number of _scales_ arguments must equal the rank of _term_1_, and each scale must be greater than `0`. A scale of `1.0` leaves that dimension unchanged.
+
+The configuration arguments _mode_, _coordinateTransformationMode_, _nearestMode_, _cubicCoeffA_, and _antialias_ have identical semantics to [`tensor:resize`](#tensorresize). See the preamble above for dispatch of _cubicCoeffA_ in this function.
+
+!!! example "Example 1"
+
+    Evaluating the SPARQL expression (2x bilinear upscaling on H and W with all defaults)
+
+    ```sparql
+    tensor:resizeByScales(
+        1.0, 1.0, 2.0, 2.0,
+        "{\"type\":\"float32\",\"shape\":[1,1,2,2],\"data\":[1, 2, 3, 4]}"^^tensor:DataTensor
+    )
+    ```
+
+    returns a `[1, 1, 4, 4]` `float32` tensor.
+
+!!! example "Example 2"
+
+    Evaluating the SPARQL expression (nearest-neighbour 3x upscaling)
+
+    ```sparql
+    tensor:resizeByScales(
+        "nearest", "asymmetric", "floor",
+        1.0, 1.0, 3.0, 3.0,
+        "{\"type\":\"int32\",\"shape\":[1,1,2,2],\"data\":[1, 2, 3, 4]}"^^tensor:DataTensor
+    )
+    ```
+
+    returns
+
+    ```turtle
+    "{\"type\": \"int32\", \"shape\": [1, 1, 6, 6], \"data\": [1, 1, 1, 2, 2, 2, 1, 1, 1, 2, 2, 2, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 3, 3, 3, 4, 4, 4, 3, 3, 3, 4, 4, 4]}"^^tensor:DataTensor
+    ```
+
+!!! example "Example 3"
+
+    Evaluating the SPARQL expression (anti-aliased bicubic downscaling with explicit PyTorch coefficient)
+
+    ```sparql
+    tensor:resizeByScales(
+        "cubic", "half_pixel", -0.75, true,
+        1.0, 1.0, 0.5, 0.5,
+        "{\"type\":\"float32\",\"shape\":[1,1,8,8],\"data\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64]}"^^tensor:DataTensor
+    )
+    ```
+
+    returns a `[1, 1, 4, 4]` `float32` tensor produced by anti-aliased bicubic downscaling.
+
+??? note "ONNX definition of this function"
+
+    === "Model description"
+
+        Model inputs and outputs:
+
+        - `input1`: A tensor of any shape and <input_type> type.
+        - `output1`: A tensor of <input_type> type with shape `floor(input_shape * scales)` per dimension.
+
+        Model variables:
+
+        - `input_type`: The data type of the input tensor, which can be any supported type.
+        - `mode_value`: The resolved value of the _mode_ argument, or `"linear"` if omitted.
+        - `coord_transform_mode_value`: The resolved value of the _coordinateTransformationMode_ argument, or `"half_pixel"` if omitted.
+        - `nearest_mode_value`: The resolved value of the _nearestMode_ argument, or `"round_prefer_floor"` if omitted.
+        - `cubic_coeff_a_value`: The resolved value of _cubicCoeffA_ as FLOAT, or `-0.75` if omitted.
+        - `antialias_value`: `1` if _antialias_ is `true`, `0` otherwise (default).
+        - `scales_length`: The number of dimensions in the output tensor, equal to the rank of `input1` and the count of double _scales_ arguments.
+        - `scales_values`: The scale factors, one per dimension, as FLOAT values.
+
+    === "Model definition"
+
+        ```pbtxt title="tensor_resize_by_scales_model.pbtxt"
+        {% include "./onnx/tensor_resize_by_scales_model.pbtxt" %}
+        ```
+
+---
+
 ### 4.2 Operators
 
 When using the binary operators, the input tensors are broadcasted to a common shape. The broadcasting rules are the same as in **[ONNX Broadcasting](https://onnx.ai/onnx/repo-docs/Broadcasting.html)**. After broadcasting, the binary operator is applied element-wise to the input tensors.

--- a/docs/index.md
+++ b/docs/index.md
@@ -869,7 +869,6 @@ The result of the function is a tensor of the same shape as the input tensor, wh
     3. If _mode_ is `"nearest"` and the next argument is `xsd:string`, it is taken as the _nearestMode_. Default: `"round_prefer_floor"`. Consumed only when _mode_ is `"nearest"`.
     4. If _mode_ is `"cubic"` and the next argument is `xsd:double`, it is taken as _cubicCoeffA_. Default: `-0.75`. Consumed only when _mode_ is `"cubic"`.
     5. If the next argument is `xsd:boolean`, it is taken as the _antialias_ flag. Default: `false`.
-    6. All remaining arguments before the trailing tensor form the shape specification (integer _sizes_ for `tensor:resize`, double _scales_ for `tensor:resizeByScales`).
 
     ??? info "Validation errors for resizing functions"
 
@@ -882,16 +881,9 @@ The result of the function is a tensor of the same shape as the input tensor, wh
         - The number of sizes/scales does not equal the rank of the input tensor.
         - Any size is less than or equal to `0`, or any scale is less than or equal to `0`.
 
-    ??? info "Dispatching _cubicCoeffA_ in `tensor:resizeByScales`"
+[tensor:DataTensor](https://w3id.org/rdf-tensor/vocab#DataTensor) **tensor:resize** ([xsd:string _mode_], [xsd:string _coordinateTransformationMode_], [xsd:string _nearestMode_], [xsd:double _cubicCoeffA_], [xsd:boolean _antialias_], [tensor:DataTensor](https://w3id.org/rdf-tensor/vocab#DataTensor) _term_1_, [tensor:DataTensor](https://w3id.org/rdf-tensor/vocab#DataTensor) _sizes_)
 
-        In `tensor:resizeByScales`, both _cubicCoeffA_ and _scales_ are `xsd:double`, so type alone cannot disambiguate them. Dispatch for _cubicCoeffA_ in this function is resolved by argument count: when _mode_ is `"cubic"`, if the number of `xsd:double` arguments remaining before the trailing tensor exceeds the rank of _term_1_ by one, the first such argument is taken as _cubicCoeffA_; otherwise _cubicCoeffA_ defaults to `-0.75`.
-
-        For example, given a rank-4 tensor, `tensor:resizeByScales("cubic", "half_pixel", -0.5, 1.0, 1.0, 2.0, 2.0, ?t)` provides 5 doubles (1 excess), then first is _cubicCoeffA_; `tensor:resizeByScales("cubic", "half_pixel", 1.0, 1.0, 2.0, 2.0, ?t)` provides 4 doubles (none excess), then _cubicCoeffA_ defaults.
-
-
-[tensor:DataTensor](https://w3id.org/rdf-tensor/vocab#DataTensor) **tensor:resize** ([xsd:string _mode_], [xsd:string _coordinateTransformationMode_], [xsd:string _nearestMode_], [xsd:double _cubicCoeffA_], [xsd:boolean _antialias_], [xsd:integer](http://www.w3.org/2001/XMLSchema#integer) ... _sizes_, [tensor:DataTensor](https://w3id.org/rdf-tensor/vocab#DataTensor) _term_1_)
-
-The result of the function is a tensor resized to the exact shape given by _sizes_, interpolating elements of _term_1_ according to _mode_ and _coordinateTransformationMode_. The number of _sizes_ arguments must equal the rank of _term_1_.
+The result of the function is a tensor resized to the exact shape given by _sizes_, interpolating elements of _term_1_ according to _mode_ and _coordinateTransformationMode_. The _sizes_ tensor must be a 1-D `int64` tensor whose length equals the rank of _term_1_.
 
 Admissible values for the configuration arguments:
 
@@ -908,8 +900,8 @@ Admissible values for the configuration arguments:
     ```sparql
     tensor:resize(
         "nearest", "asymmetric",
-        1, 1, 4, 4,
-        "{\"type\":\"int32\",\"shape\":[1,1,2,2],\"data\":[1, 2, 3, 4]}"^^tensor:DataTensor
+        "{\"type\":\"int32\",\"shape\":[1,1,2,2],\"data\":[1, 2, 3, 4]}"^^tensor:DataTensor,
+        "{\"type\":\"int64\",\"shape\":[4],\"data\":[1, 1, 4, 4]}"^^tensor:DataTensor
     )
     ```
 
@@ -926,8 +918,8 @@ Admissible values for the configuration arguments:
     ```sparql
     tensor:resize(
         "nearest", "asymmetric",
-        1, 1, 2, 2,
-        "{\"type\":\"int32\",\"shape\":[1,1,4,4],\"data\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]}"^^tensor:DataTensor
+        "{\"type\":\"int32\",\"shape\":[1,1,4,4],\"data\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]}"^^tensor:DataTensor,
+        "{\"type\":\"int64\",\"shape\":[4],\"data\":[1, 1, 2, 2]}"^^tensor:DataTensor
     )
     ```
 
@@ -943,8 +935,8 @@ Admissible values for the configuration arguments:
 
     ```sparql
     tensor:resize(
-        1, 1, 4, 4,
-        "{\"type\":\"float32\",\"shape\":[1,1,2,2],\"data\":[1, 2, 3, 4]}"^^tensor:DataTensor
+        "{\"type\":\"float32\",\"shape\":[1,1,2,2],\"data\":[1, 2, 3, 4]}"^^tensor:DataTensor,
+        "{\"type\":\"int64\",\"shape\":[4],\"data\":[1, 1, 4, 4]}"^^tensor:DataTensor
     )
     ```
 
@@ -957,8 +949,8 @@ Admissible values for the configuration arguments:
     ```sparql
     tensor:resize(
         "cubic", "half_pixel", -0.5, true,
-        1, 1, 3, 3,
-        "{\"type\":\"float32\",\"shape\":[1,1,8,8],\"data\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64]}"^^tensor:DataTensor
+        "{\"type\":\"float32\",\"shape\":[1,1,8,8],\"data\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64]}"^^tensor:DataTensor,
+        "{\"type\":\"int64\",\"shape\":[4],\"data\":[1, 1, 3, 3]}"^^tensor:DataTensor
     )
     ```
 
@@ -971,7 +963,8 @@ Admissible values for the configuration arguments:
         Model inputs and outputs:
 
         - `input1`: A tensor of any shape and <input_type> type.
-        - `output1`: A tensor of <input_type> type with shape given by the _sizes_ arguments.
+        - `input2`: A 1-D tensor of INT64 type, with length equal to the rank of `input1`, specifying the target size of each dimension.
+        - `output1`: A tensor of <input_type> type with shape given by `input2`.
 
         Model variables:
 
@@ -981,8 +974,6 @@ Admissible values for the configuration arguments:
         - `nearest_mode_value`: The resolved value of the _nearestMode_ argument, or `"round_prefer_floor"` if omitted.
         - `cubic_coeff_a_value`: The resolved value of _cubicCoeffA_ as FLOAT, or `-0.75` if omitted.
         - `antialias_value`: `1` if _antialias_ is `true`, `0` otherwise (default).
-        - `sizes_length`: The number of dimensions in the output tensor, equal to the rank of `input1` and the count of integer _sizes_ arguments.
-        - `sizes_values`: The target sizes, one per dimension, as INT64 values.
 
     === "Model definition"
 
@@ -994,20 +985,20 @@ Admissible values for the configuration arguments:
 
 #### `tensor:resizeByScales`
 
-[tensor:DataTensor](https://w3id.org/rdf-tensor/vocab#DataTensor) **tensor:resizeByScales** ([xsd:string _mode_], [xsd:string _coordinateTransformationMode_], [xsd:string _nearestMode_], [xsd:double _cubicCoeffA_], [xsd:boolean _antialias_], [xsd:double](http://www.w3.org/2001/XMLSchema#double) ... _scales_, [tensor:DataTensor](https://w3id.org/rdf-tensor/vocab#DataTensor) _term_1_)
+[tensor:DataTensor](https://w3id.org/rdf-tensor/vocab#DataTensor) **tensor:resizeByScales** ([xsd:string _mode_], [xsd:string _coordinateTransformationMode_], [xsd:string _nearestMode_], [xsd:double _cubicCoeffA_], [xsd:boolean _antialias_], [tensor:DataTensor](https://w3id.org/rdf-tensor/vocab#DataTensor) _term_1_, [tensor:DataTensor](https://w3id.org/rdf-tensor/vocab#DataTensor) _scales_)
 
-The result of the function is a tensor where each dimension is scaled by the corresponding factor in _scales_. The output size on dimension _i_ is `floor(input_size[i] * scales[i])`. The number of _scales_ arguments must equal the rank of _term_1_, and each scale must be greater than `0`. A scale of `1.0` leaves that dimension unchanged.
+The result of the function is a tensor where each dimension is scaled by the corresponding factor in _scales_. The output size on dimension _i_ is `floor(input_size[i] * scales[i])`. The _scales_ tensor must be a 1-D floating-point tensor (`float16`, `float32`, or `float64`) whose length equals the rank of _term_1_, and each value must be greater than `0`. A scale of `1.0` leaves that dimension unchanged.
 
-The configuration arguments _mode_, _coordinateTransformationMode_, _nearestMode_, _cubicCoeffA_, and _antialias_ have identical semantics to [`tensor:resize`](#tensorresize). See the preamble above for dispatch of _cubicCoeffA_ in this function.
+The configuration arguments _mode_, _coordinateTransformationMode_, _nearestMode_, _cubicCoeffA_, and _antialias_ have identical semantics to [`tensor:resize`](#tensorresize).
 
 !!! example "Example 1"
 
-    Evaluating the SPARQL expression (2x bilinear upscaling on H and W with all defaults)
-
+    Evaluating the SPARQL expression (2× bilinear upscaling on H and W with all defaults)
+ 
     ```sparql
     tensor:resizeByScales(
-        1.0, 1.0, 2.0, 2.0,
-        "{\"type\":\"float32\",\"shape\":[1,1,2,2],\"data\":[1, 2, 3, 4]}"^^tensor:DataTensor
+        "{\"type\":\"float32\",\"shape\":[1,1,2,2],\"data\":[1, 2, 3, 4]}"^^tensor:DataTensor,
+        "{\"type\":\"float32\",\"shape\":[4],\"data\":[1.0, 1.0, 2.0, 2.0]}"^^tensor:DataTensor
     )
     ```
 
@@ -1015,13 +1006,13 @@ The configuration arguments _mode_, _coordinateTransformationMode_, _nearestMode
 
 !!! example "Example 2"
 
-    Evaluating the SPARQL expression (nearest-neighbour 3x upscaling)
+    Evaluating the SPARQL expression (nearest-neighbour 3× upscaling)
 
     ```sparql
     tensor:resizeByScales(
         "nearest", "asymmetric", "floor",
-        1.0, 1.0, 3.0, 3.0,
-        "{\"type\":\"int32\",\"shape\":[1,1,2,2],\"data\":[1, 2, 3, 4]}"^^tensor:DataTensor
+        "{\"type\":\"int32\",\"shape\":[1,1,2,2],\"data\":[1, 2, 3, 4]}"^^tensor:DataTensor,
+        "{\"type\":\"float32\",\"shape\":[4],\"data\":[1.0, 1.0, 3.0, 3.0]}"^^tensor:DataTensor
     )
     ```
 
@@ -1033,13 +1024,13 @@ The configuration arguments _mode_, _coordinateTransformationMode_, _nearestMode
 
 !!! example "Example 3"
 
-    Evaluating the SPARQL expression (anti-aliased bicubic downscaling with explicit PyTorch coefficient)
+    Evaluating the SPARQL expression (anti-aliased bicubic downscaling with PyTorch coefficient)
 
     ```sparql
     tensor:resizeByScales(
         "cubic", "half_pixel", -0.75, true,
-        1.0, 1.0, 0.5, 0.5,
-        "{\"type\":\"float32\",\"shape\":[1,1,8,8],\"data\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64]}"^^tensor:DataTensor
+        "{\"type\":\"float32\",\"shape\":[1,1,8,8],\"data\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64]}"^^tensor:DataTensor,
+        "{\"type\":\"float32\",\"shape\":[4],\"data\":[1.0, 1.0, 0.5, 0.5]}"^^tensor:DataTensor
     )
     ```
 
@@ -1052,7 +1043,8 @@ The configuration arguments _mode_, _coordinateTransformationMode_, _nearestMode
         Model inputs and outputs:
 
         - `input1`: A tensor of any shape and <input_type> type.
-        - `output1`: A tensor of <input_type> type with shape `floor(input_shape * scales)` per dimension.
+        - `input2`: A 1-D tensor of FLOAT type, with length equal to the rank of `input1`, specifying the scale factor for each dimension.
+        - `output1`: A tensor of <input_type> type with shape `floor(input_shape * input2)` per dimension.
 
         Model variables:
 
@@ -1062,8 +1054,8 @@ The configuration arguments _mode_, _coordinateTransformationMode_, _nearestMode
         - `nearest_mode_value`: The resolved value of the _nearestMode_ argument, or `"round_prefer_floor"` if omitted.
         - `cubic_coeff_a_value`: The resolved value of _cubicCoeffA_ as FLOAT, or `-0.75` if omitted.
         - `antialias_value`: `1` if _antialias_ is `true`, `0` otherwise (default).
-        - `scales_length`: The number of dimensions in the output tensor, equal to the rank of `input1` and the count of double _scales_ arguments.
-        - `scales_values`: The scale factors, one per dimension, as FLOAT values.
+
+        Implementations must cast the _scales_ input tensor to FLOAT before passing it to the ONNX `Resize` operator, as required by the operator's type constraints.
 
     === "Model definition"
 

--- a/onnx/tensor_resize_by_scales_model.pbtxt
+++ b/onnx/tensor_resize_by_scales_model.pbtxt
@@ -6,7 +6,7 @@ graph {
   node {
     input: "input1"
     input: ""
-    input: "scales"
+    input: "input2"
     output: "output1"
     op_type: "Resize"
     attribute {
@@ -35,20 +35,19 @@ graph {
       type: INT
     }
   }
-  initializer {
-    dims: <scales_length>
-    data_type: 1
-    float_data: <scales_values[0]>
-    float_data: <scales_values[1]>
-    ...
-    float_data: <scales_values[scales_length-1]>
-    name: "scales"
-  }
   input {
     name: "input1"
     type {
       tensor_type {
         elem_type: <input_type>
+      }
+    }
+  }
+  input {
+    name: "input2"
+    type {
+      tensor_type {
+        elem_type: 1
       }
     }
   }

--- a/onnx/tensor_resize_by_scales_model.pbtxt
+++ b/onnx/tensor_resize_by_scales_model.pbtxt
@@ -1,0 +1,66 @@
+ir_version: 11
+domain: "eu.neverblink.rdf"
+model_version: 1
+doc_string: "RDF tensor resize by scales function"
+graph {
+  node {
+    input: "input1"
+    input: ""
+    input: "scales"
+    output: "output1"
+    op_type: "Resize"
+    attribute {
+      name: "mode"
+      s: <mode_value>
+      type: STRING
+    }
+    attribute {
+      name: "coordinate_transformation_mode"
+      s: <coord_transform_mode_value>
+      type: STRING
+    }
+    attribute {
+      name: "nearest_mode"
+      s: <nearest_mode_value>
+      type: STRING
+    }
+    attribute {
+      name: "cubic_coeff_a"
+      f: <cubic_coeff_a_value>
+      type: FLOAT
+    }
+    attribute {
+      name: "antialias"
+      i: <antialias_value>
+      type: INT
+    }
+  }
+  initializer {
+    dims: <scales_length>
+    data_type: 1
+    float_data: <scales_values[0]>
+    float_data: <scales_values[1]>
+    ...
+    float_data: <scales_values[scales_length-1]>
+    name: "scales"
+  }
+  input {
+    name: "input1"
+    type {
+      tensor_type {
+        elem_type: <input_type>
+      }
+    }
+  }
+  output {
+    name: "output1"
+    type {
+      tensor_type {
+        elem_type: <input_type>
+      }
+    }
+  }
+}
+opset_import {
+  version: 23
+}

--- a/onnx/tensor_resize_model.pbtxt
+++ b/onnx/tensor_resize_model.pbtxt
@@ -7,7 +7,7 @@ graph {
     input: "input1"
     input: ""
     input: ""
-    input: "sizes"
+    input: "input2"
     output: "output1"
     op_type: "Resize"
     attribute {
@@ -41,20 +41,19 @@ graph {
       type: STRING
     }
   }
-  initializer {
-    dims: <sizes_length>
-    data_type: 7
-    int64_data: <sizes_values[0]>
-    int64_data: <sizes_values[1]>
-    ...
-    int64_data: <sizes_values[sizes_length-1]>
-    name: "sizes"
-  }
   input {
     name: "input1"
     type {
       tensor_type {
         elem_type: <input_type>
+      }
+    }
+  }
+  input {
+    name: "input2"
+    type {
+      tensor_type {
+        elem_type: 7
       }
     }
   }

--- a/onnx/tensor_resize_model.pbtxt
+++ b/onnx/tensor_resize_model.pbtxt
@@ -1,0 +1,72 @@
+ir_version: 11
+domain: "eu.neverblink.rdf"
+model_version: 1
+doc_string: "RDF tensor resize by sizes function"
+graph {
+  node {
+    input: "input1"
+    input: ""
+    input: ""
+    input: "sizes"
+    output: "output1"
+    op_type: "Resize"
+    attribute {
+      name: "mode"
+      s: <mode_value>
+      type: STRING
+    }
+    attribute {
+      name: "coordinate_transformation_mode"
+      s: <coord_transform_mode_value>
+      type: STRING
+    }
+    attribute {
+      name: "nearest_mode"
+      s: <nearest_mode_value>
+      type: STRING
+    }
+    attribute {
+      name: "cubic_coeff_a"
+      f: <cubic_coeff_a_value>
+      type: FLOAT
+    }
+    attribute {
+      name: "antialias"
+      i: <antialias_value>
+      type: INT
+    }
+    attribute {
+      name: "keep_aspect_ratio_policy"
+      s: "stretch"
+      type: STRING
+    }
+  }
+  initializer {
+    dims: <sizes_length>
+    data_type: 7
+    int64_data: <sizes_values[0]>
+    int64_data: <sizes_values[1]>
+    ...
+    int64_data: <sizes_values[sizes_length-1]>
+    name: "sizes"
+  }
+  input {
+    name: "input1"
+    type {
+      tensor_type {
+        elem_type: <input_type>
+      }
+    }
+  }
+  output {
+    name: "output1"
+    type {
+      tensor_type {
+        elem_type: <input_type>
+      }
+    }
+  }
+}
+opset_import {
+  version: 23
+}

--- a/ontology/functions.ttl
+++ b/ontology/functions.ttl
@@ -254,3 +254,13 @@ tensor:sort a sd:Function ;
     rdfs:label "Sort Tensor" ;
     rdfs:comment "Sorts the elements of the input tensor along the specified axis in the given direction."@en ;
     dc:creator "Nikita Kozlov" .
+
+tensor:resize a sd:Function ;
+    rdfs:label "Resize Tensor" ;
+    rdfs:comment "Resizes a tensor to a new shape, interpolating values as necessary."@en ;
+    dc:creator "Nikita Kozlov" .
+
+tensor:resizeByScales a sd:Function ;
+    rdfs:label "Resize Tensor by Scales" ;
+    rdfs:comment "Resizes a tensor by specified scale factors for each dimension."@en ;
+    dc:creator "Nikita Kozlov" .


### PR DESCRIPTION
Added resize and resizeByScales functions based on ONNX's Resize operator https://onnx.ai/onnx/operators/onnx__Resize.html.
Most of parameters are supported - as in:
- `tensor:resize` allows to specify final dimensions, mode, mode-specific parameters and antialiasing
- `tensor:resizeByScales` allows to specify scales of new dimensions, mode, mode-specific parameters and antialiasing

`tf_crop_and_resize` is not supported as it does not fit functions semantics (only resizing, but not cropping is a product of a function).
